### PR TITLE
Strip any trailing commas from pulse audio volume output.

### DIFF
--- a/volume
+++ b/volume
@@ -41,7 +41,8 @@ get_volume_pulseaudio() {
 
     pacmd list-sinks |
         awk -W posix '/^[ \t]+name: /{insink = $2 == "<'$sink'>"}
-                      /^[ \t]+volume: / && insink {gsub("%", ""); print $5; exit}'
+                      /^[ \t]+volume: / && insink {gsub("%", "");
+                      gsub(",", "");  print $5; exit}'
 }
 
 # Get the volume as a percentage.


### PR DESCRIPTION
This was breaking comparisons in other functions since the trailing
comma made the expression not an integer.

For example I was getting the following errors:

```
$ ./volume -np -i 5 -x 100
./volume: line 77: [: 112,: integer expression expected
./volume: line 300: [: 117,: integer expression expected
./volume: line 301: [: 117,: integer expression expected
./volume: line 302: [: 117,: integer expression expected
./volume: line 303: [: 117,: integer expression expected
./volume: line 370: (117, > 100 ? 100 : 117,) / 5: syntax error: operand expected (error token is "> 100 ? 100 : 117,) / 5")
```