### PR TITLE
fix icon not found on mute action

### DIFF
--- a/volume
+++ b/volume
@@ -322,7 +322,7 @@ notify_muted() {
     local icon
 
     if $opt_use_fullcolor_icons; then
-        icon=icon=${icons[0]}
+        icon=${icons[0]}
     else
         icon=${icons_symbolic[0]}
     fi


### PR DESCRIPTION
The notification icon for the 'mute' action cannot be found because
of a typo. This commit fixes it.

The error can be reproduced by pressing the 'mute' key(-combo), resulting in

1. no icon displayed in the notification, and
2. `<DATE> <HOST> dunst[<PID>]: WARNING: No icon found in path: 'icon=audio-volume-muted'` in the journal.

Thx a lot for your work btw !

 _Cheers !_