### PR TITLE
Add commented-out overamplified icon name

### DIFF
--- a/volume
+++ b/volume
@@ -533,6 +533,8 @@ icons_symbolic=(
     audio-volume-high-symbolic
     audio-volume-low-symbolic
     audio-volume-medium-symbolic
+    ## Only exists in some icon sets
+    # audio-volume-overamplified-symbolic
 )
 
 sink_flags=()


### PR DESCRIPTION
The code references an optional icons_symbolic[4] a few times, but there's no guidance on what it might be named. The commented-out-by-default line in this PR should help speed up enabling this behavior for people who have the icon and want to use it.