### PR TITLE
fix: Specify assoc array for sink port aliases

### DIFF
--- a/volume
+++ b/volume
@@ -1326,6 +1326,9 @@ main() {
 
     # PulseAudio sink flags
     declare -a SINK_FLAGS=()
+    
+    # PulseAudio port aliases
+    declare -A PORT_ALIASES
 
     # PulseAudio sink ports
     declare -gA SINK_PORTS


### PR DESCRIPTION
Without specific associative array type declaration:
- the array is initialized as an indexed array
- the check at [line 751](https://github.com/hastinbe/i3-volume/blob/d7f3f44385d1dcdd7eed18d4cee291a1efc3d63b/volume#L751) fails with the following error:
```
~/.config/i3-volume/volume: line 751: %v\n: syntax error: operand expected (error token is "%v\n")
```